### PR TITLE
Fix appendChild error before DOM constructed completely

### DIFF
--- a/template/content-script.js
+++ b/template/content-script.js
@@ -11,7 +11,7 @@ function injectScript(code) {
   const script = document.createElement("script");
   script.type = "text/javascript";
   script.innerText = code;
-  document.body.appendChild(script);
+  (document.head || document.documentElement).appendChild(script);
   script.remove();
 }
 function unwrapFunctionCode(fn) {
@@ -34,6 +34,7 @@ injectScript(
         const message = { target: "@pbkit/devtools/panel", event, type };
         window.postMessage(message, "*");
       });
+      console.log("Successfully connected with @pbkit/devtools/panel");
     });
   })
 );


### PR DESCRIPTION
manifest - content_script의 [run_at](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#run_time)이 `document_start`인 경우 DOM이 완성되지 않아 body에 appendChild 하는 동작이 에러를 유발합니다.

따라서 https://github.com/SafetyCulture/grpc-web-devtools/blob/02eab1583b01e7ef7e906a560ae27662a913d25a/public/content-script.js#L110 를 참고하여 해결하였습니다.