### PR TITLE
Preserve log 기능을 구현합니다.

### DIFF
--- a/src/Events.ts
+++ b/src/Events.ts
@@ -1,6 +1,7 @@
 export default interface Events {
   request: {
     requestId: number;
+    configId: string;
     servicePath: string;
     rpcName: string;
     metadataJson: string;
@@ -8,20 +9,24 @@ export default interface Events {
   };
   "request-payload": {
     requestId: number;
+    configId: string;
     payloadJson: string;
     payloadProto: Uint8Array;
   };
   response: {
     requestId: number;
+    configId: string;
     headerJson: string;
   };
   "response-payload": {
     requestId: number;
+    configId: string;
     payloadJson: string;
     payloadProto: Uint8Array;
   };
   "response-trailer": {
     requestId: number;
+    configId: string;
     trailerJson: string;
   };
 }

--- a/src/components/Checkbox/index.module.scss
+++ b/src/components/Checkbox/index.module.scss
@@ -1,0 +1,6 @@
+.checkbox {
+  display: flex;
+  align-items: center;
+  line-height: normal;
+  column-gap: 4px;
+}

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import styles from "./index.module.scss";
+
+interface CheckboxProps {
+  isChecked: boolean;
+  onChange(value: boolean): void;
+  children?: React.ReactNode;
+}
+const Checkbox: React.FC<CheckboxProps> = ({
+  isChecked,
+  onChange,
+  children,
+  ...props
+}) => {
+  return (
+    <label className={styles.checkbox} {...props}>
+      <input
+        type="checkbox"
+        checked={isChecked}
+        onChange={(e) => onChange(e.currentTarget.checked)}
+      />
+      {children}
+    </label>
+  );
+};
+
+export default React.memo(Checkbox);

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -3,3 +3,12 @@
   grid-template-columns: 15em 1fr;
   grid-template-rows: 100vh;
 }
+
+.sidebar {
+  background-color: var(--oc-gray-2);
+  border-right: 1px solid var(--pb-sep);
+
+  @media (prefers-color-scheme: dark) {
+    background-color: var(--oc-gray-8);
+  }
+}

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -50,7 +50,8 @@ function useDevtoolsCommunicationLogic() {
     try {
       const port = chrome.runtime.connect({ name: "@pbkit/devtools/panel" });
       const tabs = chrome.tabs;
-      port.postMessage({ tabId: chrome.devtools.inspectedWindow.tabId });
+      const tabId = chrome.devtools.inspectedWindow.tabId;
+      port.postMessage({ tabId });
       interface Message {
         target: string;
         event: Events[keyof Events];
@@ -80,8 +81,11 @@ function useDevtoolsCommunicationLogic() {
           }
         }
       });
-      const listener = (_: unknown, changeInfo: chrome.tabs.TabChangeInfo) => {
-        if (changeInfo.status === "loading") {
+      const listener = (
+        eventTabId: number,
+        changeInfo: chrome.tabs.TabChangeInfo
+      ) => {
+        if (changeInfo.status === "loading" && eventTabId === tabId) {
           return !preserveLog && resetRequests();
         }
       };

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -35,9 +35,9 @@ export default Page;
 
 function useDevtoolsCommunicationLogic() {
   const updateRequests = useUpdateAtom(requestsAtom);
-  const [, setSelectedRequestSpecifier] = useAtom(selectedRequestKeyAtom);
+  const [, setSelectedRequestKey] = useAtom(selectedRequestKeyAtom);
   const resetRequests = () => {
-    setSelectedRequestSpecifier(undefined);
+    setSelectedRequestKey(undefined);
     updateRequests({});
   };
   const [preserveLog] = useAtom(preserveLogAtom);

--- a/src/pages/index/RequestList/index.module.scss
+++ b/src/pages/index/RequestList/index.module.scss
@@ -1,13 +1,8 @@
 .request-list {
+  height: 100%;
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
-  background-color: var(--oc-gray-2);
-  border-right: 1px solid var(--pb-sep);
-
-  @media (prefers-color-scheme: dark) {
-    background-color: var(--oc-gray-8);
-  }
 }
 
 .request-list-item {

--- a/src/pages/index/RequestList/index.tsx
+++ b/src/pages/index/RequestList/index.tsx
@@ -1,24 +1,24 @@
 import { memo } from "react";
 import { atom, useAtom } from "jotai";
 import { requestsAtom } from "../atoms/request";
-import { selectedRequestIdAtom } from "../atoms/ui";
+import { selectedRequestKeyAtom } from "../atoms/ui";
 import Button from "../../../components/Button";
 import style from "./index.module.scss";
 
 interface RequestListProps {}
 const RequestList: React.FC<RequestListProps> = () => {
   const [requestList] = useAtom(requestListAtom);
-  const [selectedRequestId, setSelectedRequestId] = useAtom(
-    selectedRequestIdAtom
+  const [selectedRequestKey, setSelectedRequestKey] = useAtom(
+    selectedRequestKeyAtom
   );
   return (
     <div className={style["request-list"]}>
-      {requestList.map(({ requestId, servicePath, rpcName }) => (
+      {requestList.map(({ key, servicePath, rpcName }) => (
         <Button
-          key={requestId}
+          key={key}
           className={style["request-list-item"]}
-          data-selected={requestId === selectedRequestId}
-          onClick={() => setSelectedRequestId(requestId)}
+          data-selected={key === selectedRequestKey}
+          onClick={() => setSelectedRequestKey(key)}
         >
           <div className={style["service-path"]}>{servicePath}</div>
           <div className={style["rpc-name"]}>{rpcName}</div>
@@ -31,8 +31,8 @@ export default memo(RequestList);
 
 const requestListAtom = atom((get) => {
   const requests = get(requestsAtom);
-  return Object.keys(requests).map((requestId) => {
-    const { servicePath, rpcName } = get(requests[+requestId]);
-    return { requestId, servicePath, rpcName };
+  return Object.keys(requests).map((key) => {
+    const { servicePath, rpcName } = get(requests[key]);
+    return { key, servicePath, rpcName };
   });
 });

--- a/src/pages/index/Settings/index.module.scss
+++ b/src/pages/index/Settings/index.module.scss
@@ -1,0 +1,5 @@
+.settings {
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/pages/index/Settings/index.tsx
+++ b/src/pages/index/Settings/index.tsx
@@ -1,0 +1,25 @@
+import { useAtom } from "jotai";
+import React from "react";
+import Checkbox from "../../../components/Checkbox";
+import { preserveLogAtom } from "../atoms/setting";
+import styles from "./index.module.scss";
+
+interface SettingsProps {}
+const Settings: React.FC<SettingsProps> = () => {
+  const [preserveLog, setPreserveLog] = useAtom(preserveLogAtom);
+  return (
+    <div className={styles.settings}>
+      <Checkbox
+        isChecked={preserveLog}
+        onChange={(v) => {
+          setPreserveLog(v);
+          console.log(v);
+        }}
+      >
+        Preserve log
+      </Checkbox>
+    </div>
+  );
+};
+
+export default React.memo(Settings);

--- a/src/pages/index/atoms/request.ts
+++ b/src/pages/index/atoms/request.ts
@@ -1,6 +1,14 @@
 import { atom, PrimitiveAtom } from "jotai";
 import type Events from "../../../Events";
 
+interface GetRequestKeyConfig {
+  configId: string;
+  requestId: number;
+}
+export const getRequestKey = ({ configId, requestId }: GetRequestKeyConfig) => {
+  return configId + "\0" + requestId;
+};
+
 export const requestsAtom = atom<Requests>({});
 
 export const updateRequestAtom = atom<null, Events["request"]>(
@@ -16,7 +24,7 @@ export const updateRequestAtom = atom<null, Events["request"]>(
     };
     set(requestsAtom, {
       ...requests,
-      [update.requestId]: atom(request),
+      [getRequestKey(update)]: atom(request),
     });
   }
 );
@@ -25,7 +33,7 @@ export const updateRequestPayloadAtom = atom<null, Events["request-payload"]>(
   null,
   (get, set, update) => {
     const requests = get(requestsAtom);
-    const request = get(requests[update.requestId]);
+    const request = get(requests[getRequestKey(update)]);
     const requestPayloads = get(request.requestPayloadsAtom);
     set(request.requestPayloadsAtom, [...requestPayloads, update]);
   }
@@ -35,7 +43,7 @@ export const updateResponseAtom = atom<null, Events["response"]>(
   null,
   (get, set, update) => {
     const requests = get(requestsAtom);
-    const requestAtom = requests[update.requestId];
+    const requestAtom = requests[getRequestKey(update)];
     set(requestAtom, { ...get(requestAtom), ...update });
   }
 );
@@ -44,7 +52,7 @@ export const updateResponsePayloadAtom = atom<null, Events["response-payload"]>(
   null,
   (get, set, update) => {
     const requests = get(requestsAtom);
-    const request = get(requests[update.requestId]);
+    const request = get(requests[getRequestKey(update)]);
     const responsePayloads = get(request.responsePayloadsAtom);
     set(request.responsePayloadsAtom, [...responsePayloads, update]);
   }
@@ -54,13 +62,13 @@ export const updateResponseTrailerAtom = atom<null, Events["response-trailer"]>(
   null,
   (get, set, update) => {
     const requests = get(requestsAtom);
-    const requestAtom = requests[update.requestId];
+    const requestAtom = requests[getRequestKey(update)];
     set(requestAtom, { ...get(requestAtom), ...update });
   }
 );
 
 export interface Requests {
-  [requestId: number]: PrimitiveAtom<Request>;
+  [key: string]: PrimitiveAtom<Request>;
 }
 
 export interface Request {

--- a/src/pages/index/atoms/setting.ts
+++ b/src/pages/index/atoms/setting.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const preserveLogAtom = atom<boolean>(false);

--- a/src/pages/index/atoms/ui.ts
+++ b/src/pages/index/atoms/ui.ts
@@ -1,10 +1,12 @@
 import { atom } from "jotai";
 import { requestsAtom } from "./request";
 
-export const selectedRequestIdAtom = atom<string | undefined>(undefined);
+export const selectedRequestKeyAtom = atom<string | undefined>(undefined);
 
 export const selectedRequestAtom = atom((get) => {
   const requests = get(requestsAtom);
-  const selectedRequestId = get(selectedRequestIdAtom);
-  return selectedRequestId ? get(requests[+selectedRequestId]) : undefined;
+  const selectedRequestKey = get(selectedRequestKeyAtom);
+  if (!selectedRequestKey) return undefined;
+  const selectedRequestAtom = requests[selectedRequestKey];
+  return selectedRequestAtom ? get(selectedRequestAtom) : undefined;
 });

--- a/src/pages/index/atoms/ui.ts
+++ b/src/pages/index/atoms/ui.ts
@@ -8,5 +8,5 @@ export const selectedRequestAtom = atom((get) => {
   const selectedRequestKey = get(selectedRequestKeyAtom);
   if (!selectedRequestKey) return undefined;
   const selectedRequestAtom = requests[selectedRequestKey];
-  return selectedRequestAtom ? get(selectedRequestAtom) : undefined;
+  return selectedRequestAtom && get(selectedRequestAtom);
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49385012/148495687-6c371d72-cb0e-49ca-9a83-279b588dcd4f.png)

- Checkbox 구현
- Events에 sessionId 추가
- Requests의 구조 변경 → RequestStorage로 rename

New feature
- tab refresh (content-scripts가 새로 실행되는 시점) + javascript routing에서 로그를 잃지 않도록 수정